### PR TITLE
pidfile init时候先删除

### DIFF
--- a/src/Server/SwooleServer.php
+++ b/src/Server/SwooleServer.php
@@ -233,7 +233,7 @@ abstract class SwooleServer extends Child
         if (empty(self::$pidFile)) {
             self::$pidFile = __DIR__ . "/../" . str_replace('/', '_', self::$_startFile) . ".pid";
         }
-
+        @unlink(self::$pidFile);
         // Process title.
         self::setProcessTitle('SWD');
     }


### PR DESCRIPTION
fix在某些特殊情况导致server没启动还提示启动的问题